### PR TITLE
PF 7.0, Jetty 0.94, Added Dialog Framework to faces-config.xml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.primefaces</groupId>
             <artifactId>primefaces</artifactId>
-            <version>6.2</version>
+            <version>7.0</version>
         </dependency>
 
         <!-- javax.* APIs -->
@@ -132,7 +132,7 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>9.4.11.v20180605</version>
+                <version>9.4.15.v20190215</version>
                 <configuration>
                     <webAppConfig>
                         <contextPath>/primefaces-test</contextPath>
@@ -207,7 +207,7 @@
                 <dependency>
                     <groupId>org.glassfish</groupId>
                     <artifactId>javax.faces</artifactId>
-                    <version>2.3.5</version>
+                    <version>2.3.9</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/src/main/webapp/WEB-INF/faces-config.xml
+++ b/src/main/webapp/WEB-INF/faces-config.xml
@@ -3,4 +3,9 @@
               xmlns="http://xmlns.jcp.org/xml/ns/javaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd">
+    <application>
+        <action-listener>org.primefaces.application.DialogActionListener</action-listener>
+        <navigation-handler>org.primefaces.application.DialogNavigationHandler</navigation-handler>
+        <view-handler>org.primefaces.application.DialogViewHandler</view-handler>
+    </application>
 </faces-config>


### PR DESCRIPTION
Updated to PF 7.0
Updated to latest Jetty plugin to address security issues.
Added dialog framework to faces-config.xml because it took me forever to figure out why my Dialog Framework test case was not working.  Want to save others in the future.