### PR TITLE
Add maven profile switches to allow application to run in Payara5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target/
+/.idea/
 .classpath
 .project
 .settings

--- a/README.md
+++ b/README.md
@@ -5,13 +5,17 @@ This is a sample maven project that used <strong>PF10.0.0</strong> version. If y
 
 You can execute the sample with <strong>mvn jetty:run</strong> command and hit <strong>http://localhost:8080/primefaces-test</strong> to run the page.
 
-Per default the application uses Mojarra 2.2.x. 
-You can also use other versions with the available maven profiles: myfaces22, myfaces23, mojarra23
+Per default the application uses Mojarra 2.2.x running in Jetty w/ Apache OpenWebBeans. 
+You can also use other JSF implementation versions with the available maven profiles: myfaces22, myfaces23, mojarra23
 
-`mvn clean jetty:run -Pmyfaces22`
+`mvn clean jetty:run -Pjetty-owb,myfaces22`
 
-`mvn clean jetty:run -Pmyfaces23`
+`mvn clean jetty:run -Pjetty-owb,myfaces23`
 
-`mvn clean jetty:run -Pmojarra22`
+`mvn clean jetty:run -Pjetty-owb,mojarra22`
 
-`mvn clean jetty:run -Pmojarra23`
+`mvn clean jetty:run -Pjetty-owb,mojarra23`
+
+A maven profile also exists which allows the test application to be run in Payara5 with its own embedded Mojarra
+
+`mvn clean package payara-micro:start -Ppayara5`

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,6 @@
     <properties>
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <owb.version>2.0.23</owb.version>
-        <jetty.version>9.4.43.v20210629</jetty.version>
     </properties>
 
     <dependencies>
@@ -22,79 +19,6 @@
             <groupId>org.primefaces</groupId>
             <artifactId>primefaces</artifactId>
             <version>10.0.0</version>
-        </dependency>
-
-        <!-- javax.* APIs -->
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-atinject_1.0_spec</artifactId>
-            <version>1.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jcdi_2.0_spec</artifactId>
-            <version>1.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-interceptor_1.2_spec</artifactId>
-            <version>1.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-annotation_1.3_spec</artifactId>
-            <version>1.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-validation_2.0_spec</artifactId>
-            <version>1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.3.5</version>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <version>3.0.0</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- OpenWebBeans -->
-        <dependency>
-            <groupId>org.apache.openwebbeans</groupId>
-            <artifactId>openwebbeans-impl</artifactId>
-            <version>${owb.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.openwebbeans</groupId>
-            <artifactId>openwebbeans-jsf</artifactId>
-            <version>${owb.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.openwebbeans</groupId>
-            <artifactId>openwebbeans-web</artifactId>
-            <version>${owb.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.openwebbeans</groupId>
-            <artifactId>openwebbeans-el22</artifactId>
-            <version>${owb.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.bval</groupId>
-            <artifactId>bval-jsr</artifactId>
-            <version>2.0.5</version>
         </dependency>
 
         <dependency>
@@ -147,19 +71,6 @@
                     <webXml>${project.build.directory}/web.xml</webXml>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <version>${jetty.version}</version>
-                <configuration>
-                    <webAppConfig>
-                        <contextPath>/primefaces-test</contextPath>
-                        <jettyEnvXml>${project.basedir}/src/main/conf/jetty-env.xml</jettyEnvXml>
-                    </webAppConfig>
-                    <scanIntervalSeconds>5</scanIntervalSeconds>
-                    <webXml>${project.build.directory}/web.xml</webXml>
-                </configuration>
-            </plugin>
         </plugins>
 
         <resources>
@@ -178,6 +89,174 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>jetty-owb</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <owb.version>2.0.23</owb.version>
+                <jetty.version>9.4.43.v20210629</jetty.version>
+            </properties>
+            <dependencies>
+                <!-- javax.* / jakarta.* APIs (v8 is javax v9+ is jakarta) -->
+                <dependency>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-atinject_1.0_spec</artifactId>
+                    <version>1.2</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-jcdi_2.0_spec</artifactId>
+                    <version>1.3</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-interceptor_1.2_spec</artifactId>
+                    <version>1.2</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-annotation_1.3_spec</artifactId>
+                    <version>1.3</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-validation_2.0_spec</artifactId>
+                    <version>1.1</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
+                    <version>2.3.5</version>
+                </dependency>
+                <dependency>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                    <version>4.0.1</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>javax.el</groupId>
+                    <artifactId>javax.el-api</artifactId>
+                    <version>3.0.0</version>
+                    <scope>provided</scope>
+                </dependency>
+
+                <!-- OpenWebBeans (Apache CDI Impl) -->
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-impl</artifactId>
+                    <version>${owb.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-jsf</artifactId>
+                    <version>${owb.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-web</artifactId>
+                    <version>${owb.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-el22</artifactId>
+                    <version>${owb.version}</version>
+                </dependency>
+                <!-- BVal (Apache Bean Validation Impl) -->
+                <dependency>
+                    <groupId>org.apache.bval</groupId>
+                    <artifactId>bval-jsr</artifactId>
+                    <version>2.0.5</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <filters>
+                    <filter>${basedir}/src/main/conf/mojarra.properties</filter>
+                    <filter>${basedir}/src/main/conf/openwebbeans.properties</filter>
+                </filters>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-maven-plugin</artifactId>
+                        <version>${jetty.version}</version>
+                        <configuration>
+                            <webAppConfig>
+                                <contextPath>/primefaces-test</contextPath>
+                                <jettyEnvXml>${project.basedir}/src/main/conf/jetty-env.xml</jettyEnvXml>
+                            </webAppConfig>
+                            <scanIntervalSeconds>5</scanIntervalSeconds>
+                            <webXml>${project.build.directory}/web.xml</webXml>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>payara5</id>
+            <properties>
+                <dependency.payara.version>5.2021.5</dependency.payara.version>
+                <payara-micro-maven-plugin.version>1.4.0</payara-micro-maven-plugin.version>
+                <deploy.http.port>8080</deploy.http.port>
+            </properties>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>fish.payara.api</groupId>
+                        <artifactId>payara-bom</artifactId>
+                        <version>${dependency.payara.version}</version>
+                        <scope>import</scope>
+                        <type>pom</type>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+            <dependencies>
+                <dependency>
+                    <groupId>jakarta.platform</groupId>
+                    <artifactId>jakarta.jakartaee-api</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <filters>
+                    <filter>${basedir}/src/main/conf/payara.properties</filter>
+                </filters>
+                <plugins>
+                    <plugin>
+                        <groupId>fish.payara.maven.plugins</groupId>
+                        <artifactId>payara-micro-maven-plugin</artifactId>
+                        <version>${payara-micro-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <payaraVersion>${dependency.payara.version}</payaraVersion>
+                            <artifactItem>
+                                <groupId>fish.payara.extras</groupId>
+                                <artifactId>payara-micro</artifactId>
+                                <version>${dependency.payara.version}</version>
+                            </artifactItem>
+                            <deployWar>true</deployWar>
+                            <contextRoot>/${project.name}</contextRoot>
+                            <commandLineOptions>
+                                <option>
+                                    <key>--disablephonehome</key>
+                                </option>
+                                <option>
+                                    <key>--port</key>
+                                    <value>${deploy.http.port}</value>
+                                </option>
+                            </commandLineOptions>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>myfaces22</id>
             <dependencies>

--- a/src/main/conf/openwebbeans.properties
+++ b/src/main/conf/openwebbeans.properties
@@ -1,0 +1,1 @@
+cdi-listener=org.apache.webbeans.servlet.WebBeansConfigurationListener

--- a/src/main/conf/payara.properties
+++ b/src/main/conf/payara.properties
@@ -1,0 +1,2 @@
+cdi-listener=org.primefaces.NoopCDIListener
+jsf-listener=org.primefaces.NoopJSFListener

--- a/src/main/java/org/primefaces/NoopCDIListener.java
+++ b/src/main/java/org/primefaces/NoopCDIListener.java
@@ -1,0 +1,21 @@
+package org.primefaces;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+public class NoopCDIListener implements ServletContextListener {
+
+    public NoopCDIListener() {
+    }
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        // NOOP
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+        // NOOP
+    }
+
+}

--- a/src/main/java/org/primefaces/NoopJSFListener.java
+++ b/src/main/java/org/primefaces/NoopJSFListener.java
@@ -1,0 +1,22 @@
+package org.primefaces;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+
+public class NoopJSFListener implements ServletContextListener {
+
+    public NoopJSFListener() {
+    }
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        // NOOP
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+        // NOOP
+    }
+
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -25,7 +25,7 @@
     </context-param>
 
     <listener>
-        <listener-class>org.apache.webbeans.servlet.WebBeansConfigurationListener</listener-class>
+        <listener-class>${cdi-listener}</listener-class>
     </listener>
     <listener>
         <listener-class>${jsf-listener}</listener-class>


### PR DESCRIPTION
This change reworks maven profile configuration mechanism to enable switching between Jetty and Payara5.

It factors all jetty+openwebbeans specific artifacts and configuration into a new jetty-owb maven profile, and adds payara5 profile which specifies noop web listeners for cdi/jsf boostrap (since payara automatically bootstraps Mojarra and Weld internally).