### PR TITLE
Fix duplicate lombok version tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.36</version>
             <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
It was mistakenly added by dependabot in an earlier commit