### PR TITLE
Updated Payara support (Payara v5 using javax namespace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,44 +2,68 @@
 
 # PrimeFaces Test
 
-This is a sample maven project that uses <strong>Latest PrimeFaces Release</strong> version. If you have a PrimeFaces issue, please download or fork this project. Then, you should change these files by yourself so that PrimeFaces Team can see your problem. Finally, you can send a link or attach the project. <strong>Please make sure that project is runnable with the command below.</strong>
+This is a sample maven project that uses **Latest PrimeFaces Release** version. If you have a PrimeFaces issue, please download or fork this project. Then, you should change these files by yourself so that PrimeFaces Team can see your problem. Finally, you can send a link or attach the project. **Please make sure that the project is runnable with the command below**.
 
-You can execute the sample with <strong>mvn jetty:run</strong> command and hit <strong>http://localhost:8080/</strong> to run the page.
+You can execute the sample against Jetty/OpenWebBeans with the `mvn jetty:run` maven command and navigate to **http://localhost:8080/** to access the page.
 
-### JSF Versions
-***
-
-Per default the application uses Mojarra 2.3.x. 
-You can also use other versions with the available maven profiles: myfaces23, myfaces23next, mojarra23
-
-`mvn clean jetty:run -Pmyfaces23`
-
-`mvn clean jetty:run -Pmyfaces23next`
-
-`mvn clean jetty:run -Pmojarra23`
-
-### Server Port
-***
-
-By default the application runs on port 8080 but if you would like to use a different port you can pass `-Djetty.port=5000` like:
-
-`mvn clean jetty:run -Djetty.port=5000`
+This project is configured to produce Java bytecode compatible with Java 11 and higher.  Java versions before Java 11 are no longer supported.
 
 ### Jakarta EE10 Version
 ***
 
-The branch `jakarta` contains a PrimeFaces Test setup to run again Jakarta EE10 profile using Jetty 11. You can also use other versions with the available maven profiles: mojarra40, myfaces40
+PrimeFaces Test is set up by default to run against Jakarta EE10 profile using Jetty 12. You can also use other JSF implementations with the available maven profiles: `mojarra40`, `myfaces40`.  When specifying additional maven profiles, it is necessary to also explicitly include specification of the `jetty` profile.
 
-`mvn clean jetty:run -Pmojarra40`
+`mvn clean jetty:run -Pjetty,mojarra40`
 
-`mvn clean jetty:run -Pmyfaces40`
+`mvn clean jetty:run -Pjetty,myfaces40`
+
+### Server Port
+***
+
+By default, the application runs on port 8080 but if you would like to use a different port you can pass `-Djetty.port=5000` like:
+
+`mvn clean jetty:run -Djetty.port=5000`
 
 ### JPA Lazy Datatable
 ***
 
 The branch `jpa` contains a PrimeFaces Test setup to run with JPA using the JPA LazyDatatable advanced example.
 
+### Legacy JSF Versions
+***
+
+The branch `javax` contains a PrimeFaces Test setup to run against Jakarta EE10 profile using Jetty 9. Per default the application uses Mojarra 2.3.x.
+This maven project uses maven profiles to configure web container and JSF implementations/versions.  By default, the profiles for Jetty/OpenWebBeans and the Mojarra 2.3.x JSF implementations are enabled, but it is also possible to use other JSF implementations and versions with combinations of available maven profiles: jetty-owb, myfaces23, myfaces23next, mojarra23
+
+`mvn clean jetty:run -Pjetty,myfaces23`
+
+`mvn clean jetty:run -Pjetty,myfaces23next`
+
+`mvn clean jetty:run -Pjetty,mojarra23`
+
 ### Visual Studio Code Quickstart
 ***
 
 See the [quickstart guide for running in Visual Studio Code](./vscode-quickstart.md) for more information.
+
+### Running with Payara
+***
+
+The `payara5-javax` and `payara6-jakarta` branches contain a PrimeFaces Test setup to run against a JavaEE/JakartaEE profile using Payara v5/v6 and its bundled Mojarra implementation of the Faces specification.  When using this setup, it is possible to use the `payara-micro:start` command and navigate to <strong>http://localhost:8080/</strong> to access the page.
+
+For the `payara5-javax` branch, Payara v5 will be used, supports JavaEE/JakartaEE v8/v9/v9.1 with the javax package
+  namespace, and works with Java11 and Java17. Use it with the following maven invocation:
+
+`mvn clean verify payara-micro:start -Ppayara5`
+
+A custom port can also be specified:
+
+`mvn clean verify payara-micro:start -Ppayara5 -Dpayara5.port=5000`
+
+For the `payara6-jakarta` branch, Payara v6 will be used, supports JakartaEE v10 with the jakarta package namespace, and works with Java11 through Java21. Use it with the following maven invocation:
+
+`mvn clean verify payara-micro:start -Ppayara6`
+
+A custom port can also be specified:
+
+`mvn clean verify payara-micro:start -Ppayara6 -Dpayara6.port=5000`

--- a/pom.xml
+++ b/pom.xml
@@ -10,84 +10,16 @@
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <owb.version>2.0.27</owb.version>
-        <jetty.version>9.4.54.v20240208</jetty.version>
+        <!-- jetty-specific properties -->
         <jetty.port>8080</jetty.port>
+        <jetty.version>9.4.54.v20240208</jetty.version>
+        <owb.version>2.0.27</owb.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.primefaces</groupId>
             <artifactId>primefaces</artifactId>
             <version>15.0.3</version>
-        </dependency>
-        <!-- javax.* APIs -->
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-atinject_1.0_spec</artifactId>
-            <version>1.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jcdi_2.0_spec</artifactId>
-            <version>1.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-interceptor_1.2_spec</artifactId>
-            <version>1.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-annotation_1.3_spec</artifactId>
-            <version>1.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-validation_2.0_spec</artifactId>
-            <version>1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.3.6</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <version>3.0.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <!-- OpenWebBeans -->
-        <dependency>
-            <groupId>org.apache.openwebbeans</groupId>
-            <artifactId>openwebbeans-impl</artifactId>
-            <version>${owb.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.openwebbeans</groupId>
-            <artifactId>openwebbeans-jsf</artifactId>
-            <version>${owb.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.openwebbeans</groupId>
-            <artifactId>openwebbeans-web</artifactId>
-            <version>${owb.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.openwebbeans</groupId>
-            <artifactId>openwebbeans-el22</artifactId>
-            <version>${owb.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.bval</groupId>
-            <artifactId>bval-jsr</artifactId>
-            <version>2.0.6</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -138,24 +70,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <version>${jetty.version}</version>
-                <configuration>
-                    <webAppConfig>
-                        <contextPath>/</contextPath>
-                        <jettyEnvXml>${project.basedir}/src/main/conf/jetty-env.xml</jettyEnvXml>
-                    </webAppConfig>
-                    <scanIntervalSeconds>5</scanIntervalSeconds>
-                    <webXml>${project.build.directory}/web.xml</webXml>
-                    <httpConnector>
-                        <host>0.0.0.0</host>
-                        <port>${jetty.port}</port>
-                        <idleTimeout>60000</idleTimeout>
-                    </httpConnector>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>3.5.0</version>
@@ -191,6 +105,105 @@
         </resources>
     </build>
     <profiles>
+        <profile>
+            <id>jetty</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <!-- javax.* APIs -->
+                <dependency>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-atinject_1.0_spec</artifactId>
+                    <version>1.2</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-jcdi_2.0_spec</artifactId>
+                    <version>1.3</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-interceptor_1.2_spec</artifactId>
+                    <version>1.2</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-annotation_1.3_spec</artifactId>
+                    <version>1.3</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-validation_2.0_spec</artifactId>
+                    <version>1.1</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
+                    <version>2.3.6</version>
+                </dependency>
+                <dependency>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                    <version>4.0.1</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>javax.el</groupId>
+                    <artifactId>javax.el-api</artifactId>
+                    <version>3.0.0</version>
+                    <scope>provided</scope>
+                </dependency>
+                <!-- OpenWebBeans -->
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-impl</artifactId>
+                    <version>${owb.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-jsf</artifactId>
+                    <version>${owb.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-web</artifactId>
+                    <version>${owb.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-el22</artifactId>
+                    <version>${owb.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.bval</groupId>
+                    <artifactId>bval-jsr</artifactId>
+                    <version>2.0.6</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-maven-plugin</artifactId>
+                        <version>${jetty.version}</version>
+                        <configuration>
+                            <webAppConfig>
+                                <contextPath>/</contextPath>
+                                <jettyEnvXml>${project.basedir}/src/main/conf/jetty-env.xml</jettyEnvXml>
+                            </webAppConfig>
+                            <scanIntervalSeconds>5</scanIntervalSeconds>
+                            <webXml>${project.build.directory}/web.xml</webXml>
+                            <httpConnector>
+                                <host>0.0.0.0</host>
+                                <port>${jetty.port}</port>
+                                <idleTimeout>60000</idleTimeout>
+                            </httpConnector>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>myfaces23</id>
             <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,10 @@
         <jetty.port>8080</jetty.port>
         <jetty.version>9.4.54.v20240208</jetty.version>
         <owb.version>2.0.27</owb.version>
+        <!-- payara5-specific properties -->
+        <payara5.version>5.2022.5</payara5.version>
+        <payara5.port>8080</payara5.port>
+        <payara-micro-maven-plugin.version>2.4</payara-micro-maven-plugin.version> <!-- v2.0 is the latest version that works with java8 / v2.1 and later work w/ java11+ -->
     </properties>
     <dependencies>
         <dependency>
@@ -182,6 +186,10 @@
                 </dependency>
             </dependencies>
             <build>
+                <filters>
+                    <filter>${basedir}/src/main/conf/mojarra.properties</filter>
+                    <filter>${basedir}/src/main/conf/openwebbeans.properties</filter>
+                </filters>
                 <plugins>
                     <plugin>
                         <groupId>org.eclipse.jetty</groupId>
@@ -260,6 +268,60 @@
                 <filters>
                     <filter>${project.basedir}/src/main/conf/mojarra.properties</filter>
                 </filters>
+            </build>
+        </profile>
+        <profile>
+            <id>payara5</id>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>fish.payara.api</groupId>
+                        <artifactId>payara-bom</artifactId>
+                        <version>${payara5.version}</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+            <dependencies>
+                <dependency>
+                    <groupId>fish.payara.extras</groupId>
+                    <artifactId>payara-micro</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>jakarta.platform</groupId>
+                    <artifactId>jakarta.jakartaee-api</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <filters>
+                    <filter>${basedir}/src/main/conf/payara.properties</filter>
+                </filters>
+                <plugins>
+                    <plugin>
+                        <groupId>fish.payara.maven.plugins</groupId>
+                        <artifactId>payara-micro-maven-plugin</artifactId>
+                        <version>${payara-micro-maven-plugin.version}</version>
+                        <configuration>
+                            <payaraVersion>${payara5.version}</payaraVersion>
+                            <deployWar>true</deployWar>
+                            <commandLineOptions>
+                                <option>
+                                    <key>--disablephonehome</key>
+                                </option>
+                                <option>
+                                    <key>--port</key>
+                                    <value>${payara5.port}</value>
+                                </option>
+                                <option>
+                                    <key>--nocluster</key>
+                                </option>
+                            </commandLineOptions>
+                            <contextRoot>/</contextRoot>
+                        </configuration>
+                    </plugin>
+                </plugins>
             </build>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,25 @@
     <properties>
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <maven.compiler.release>11</maven.compiler.release>
+        <maven.min.version>3.2.5</maven.min.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- dependency version properties -->
+        <primefaces.version>15.0.3</primefaces.version>
+
+        <bval-jsr.version>2.0.6</bval-jsr.version>
+        <el-api.version>3.0.0</el-api.version>
+        <geronimo-atinject10-spec.version>1.2</geronimo-atinject10-spec.version>
+        <geronimo-cdi2-spec.version>1.3</geronimo-cdi2-spec.version>
+        <geronimo-interceptor12-spec.version>1.2</geronimo-interceptor12-spec.version>
+        <geronimo-annotation13-spec.version>1.3</geronimo-annotation13-spec.version>
+        <geronimo-validation2-spec.version>1.1</geronimo-validation2-spec.version>
+        <jaxb-impl.version>2.3.6</jaxb-impl.version>
+        <lombok.version>1.18.38</lombok.version>
+        <mojarra.version>2.3.21</mojarra.version>
+        <myfaces.version>2.3.11</myfaces.version>
+        <myfaces-next.version>2.3-next-M8</myfaces-next.version>
+        <servlet-api.version>4.0.1</servlet-api.version>
+
         <!-- jetty-specific properties -->
         <jetty.port>8080</jetty.port>
         <jetty.version>9.4.54.v20240208</jetty.version>
@@ -17,18 +35,22 @@
         <!-- payara5-specific properties -->
         <payara5.version>5.2022.5</payara5.version>
         <payara5.port>8080</payara5.port>
+        <!-- plugin versions -->
+        <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
+        <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
+        <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
         <payara-micro-maven-plugin.version>2.4</payara-micro-maven-plugin.version> <!-- v2.0 is the latest version that works with java8 / v2.1 and later work w/ java11+ -->
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.primefaces</groupId>
             <artifactId>primefaces</artifactId>
-            <version>15.0.3</version>
+            <version>${primefaces.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.38</version>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -50,7 +72,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.0</version>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
@@ -58,7 +80,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>${maven-war-plugin.version}</version>
                 <configuration>
                     <webResources>
                         <resource>
@@ -76,7 +98,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>${maven-enforcer-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -86,7 +108,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.2.5</version>
+                                    <version>${maven.min.version}</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>
@@ -119,43 +141,43 @@
                 <dependency>
                     <groupId>org.apache.geronimo.specs</groupId>
                     <artifactId>geronimo-atinject_1.0_spec</artifactId>
-                    <version>1.2</version>
+                    <version>${geronimo-atinject10-spec.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.geronimo.specs</groupId>
                     <artifactId>geronimo-jcdi_2.0_spec</artifactId>
-                    <version>1.3</version>
+                    <version>${geronimo-cdi2-spec.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.geronimo.specs</groupId>
                     <artifactId>geronimo-interceptor_1.2_spec</artifactId>
-                    <version>1.2</version>
+                    <version>${geronimo-interceptor12-spec.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.geronimo.specs</groupId>
                     <artifactId>geronimo-annotation_1.3_spec</artifactId>
-                    <version>1.3</version>
+                    <version>${geronimo-annotation13-spec.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.geronimo.specs</groupId>
                     <artifactId>geronimo-validation_2.0_spec</artifactId>
-                    <version>1.1</version>
+                    <version>${geronimo-validation2-spec.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>com.sun.xml.bind</groupId>
                     <artifactId>jaxb-impl</artifactId>
-                    <version>2.3.6</version>
+                    <version>${jaxb-impl.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>javax.servlet</groupId>
                     <artifactId>javax.servlet-api</artifactId>
-                    <version>4.0.1</version>
+                    <version>${servlet-api.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
                     <groupId>javax.el</groupId>
                     <artifactId>javax.el-api</artifactId>
-                    <version>3.0.0</version>
+                    <version>${el-api.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <!-- OpenWebBeans -->
@@ -182,7 +204,7 @@
                 <dependency>
                     <groupId>org.apache.bval</groupId>
                     <artifactId>bval-jsr</artifactId>
-                    <version>2.0.6</version>
+                    <version>${bval-jsr.version}</version>
                 </dependency>
             </dependencies>
             <build>
@@ -218,12 +240,12 @@
                 <dependency>
                     <groupId>org.apache.myfaces.core</groupId>
                     <artifactId>myfaces-api</artifactId>
-                    <version>2.3.11</version>
+                    <version>${myfaces.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.myfaces.core</groupId>
                     <artifactId>myfaces-impl</artifactId>
-                    <version>2.3.11</version>
+                    <version>${myfaces.version}</version>
                 </dependency>
             </dependencies>
             <build>
@@ -238,12 +260,12 @@
                 <dependency>
                     <groupId>org.apache.myfaces.core</groupId>
                     <artifactId>myfaces-api</artifactId>
-                    <version>2.3-next-M8</version>
+                    <version>${myfaces-next.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.myfaces.core</groupId>
                     <artifactId>myfaces-impl</artifactId>
-                    <version>2.3-next-M8</version>
+                    <version>${myfaces-next.version}</version>
                 </dependency>
             </dependencies>
             <build>
@@ -261,7 +283,7 @@
                 <dependency>
                     <groupId>org.glassfish</groupId>
                     <artifactId>jakarta.faces</artifactId>
-                    <version>2.3.21</version>
+                    <version>${mojarra.version}</version>
                 </dependency>
             </dependencies>
             <build>

--- a/src/main/conf/openwebbeans.properties
+++ b/src/main/conf/openwebbeans.properties
@@ -1,0 +1,1 @@
+cdi-listener=org.apache.webbeans.servlet.WebBeansConfigurationListener

--- a/src/main/conf/payara.properties
+++ b/src/main/conf/payara.properties
@@ -1,0 +1,2 @@
+cdi-listener=org.primefaces.listeners.NoopCDIListener
+jsf-listener=org.primefaces.listeners.NoopJSFListener

--- a/src/main/java/org/primefaces/listeners/NoopCDIListener.java
+++ b/src/main/java/org/primefaces/listeners/NoopCDIListener.java
@@ -1,0 +1,19 @@
+package org.primefaces.listeners;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+public class NoopCDIListener implements ServletContextListener {
+
+    public NoopCDIListener() {
+    }
+
+    public void contextInitialized(ServletContextEvent sce) {
+        // NOOP
+    }
+
+    public void contextDestroyed(ServletContextEvent sce) {
+        // NOOP
+    }
+
+}

--- a/src/main/java/org/primefaces/listeners/NoopJSFListener.java
+++ b/src/main/java/org/primefaces/listeners/NoopJSFListener.java
@@ -1,0 +1,19 @@
+package org.primefaces.listeners;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+public class NoopJSFListener implements ServletContextListener {
+
+    public NoopJSFListener() {
+    }
+
+    public void contextInitialized(ServletContextEvent sce) {
+        // NOOP
+    }
+
+    public void contextDestroyed(ServletContextEvent sce) {
+        // NOOP
+    }
+
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -25,7 +25,7 @@
     </context-param>
 
     <listener>
-        <listener-class>org.apache.webbeans.servlet.WebBeansConfigurationListener</listener-class>
+        <listener-class>${cdi-listener}</listener-class>
     </listener>
     <listener>
         <listener-class>${jsf-listener}</listener-class>


### PR DESCRIPTION
Similar to PR #539, this PR contains changes against javax branch to add support for Payara v5 w/ javax package namespace.  Proposal is to NOT merge to javax branch, but rather create a separate payara5-javax branch to maintain this code somewhat out-of-band from the javax branch.

Additionally, this PR is functionally a replacement for the older payara branch in this repo.