### PR TITLE
Payara branch maintenance (Updates as of 2025-06-12)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- dependency version properties -->
-        <primefaces.version>15.0.3</primefaces.version>
+        <primefaces.version>15.0.4</primefaces.version>
 
         <bval-jsr.version>2.0.6</bval-jsr.version>
         <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <weld-servlet-core.version>6.0.2.Final</weld-servlet-core.version>
         <!-- jetty-specific properties -->
         <jetty.port>8080</jetty.port>
-        <jetty.version>12.0.20</jetty.version>
+        <jetty.version>12.0.21</jetty.version>
         <!-- payara-specific properties -->
         <payara6.port>8080</payara6.port>
         <payara6.version>6.2025.4</payara6.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <weld-servlet-core.version>6.0.2.Final</weld-servlet-core.version>
         <!-- jetty-specific properties -->
         <jetty.port>8080</jetty.port>
-        <jetty.version>12.0.19</jetty.version>
+        <jetty.version>12.0.20</jetty.version>
         <!-- payara-specific properties -->
         <payara6.port>8080</payara6.port>
         <payara6.version>6.2025.4</payara6.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <lombok.version>1.18.38</lombok.version>
         <mojarra.version>4.0.11</mojarra.version>
         <myfaces.version>4.0.3</myfaces.version>
-        <weld-servlet-core.version>6.0.2.Final</weld-servlet-core.version>
+        <weld-servlet-core.version>6.0.3.Final</weld-servlet-core.version>
         <!-- jetty-specific properties -->
         <jetty.port>8080</jetty.port>
         <jetty.version>12.0.21</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <jetty.version>12.0.22</jetty.version>
         <!-- payara-specific properties -->
         <payara6.port>8080</payara6.port>
-        <payara6.version>6.2025.4</payara6.version>
+        <payara6.version>6.2025.6</payara6.version>
         <!-- plugin versions -->
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <maven-war-plugin.version>3.4.0</maven-war-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <weld-servlet-core.version>6.0.3.Final</weld-servlet-core.version>
         <!-- jetty-specific properties -->
         <jetty.port>8080</jetty.port>
-        <jetty.version>12.0.21</jetty.version>
+        <jetty.version>12.0.22</jetty.version>
         <!-- payara-specific properties -->
         <payara6.port>8080</payara6.port>
         <payara6.version>6.2025.4</payara6.version>


### PR DESCRIPTION
**Dependency Upgrades**
- `PrimeFaces`: `15.0.3` → `15.0.4`
- `Jetty`: `12.0.19` → `12.0.22`
- `Payara6`: `6.2025.4` → `6.2025.6`
- `Weld Servlet Core`: `6.0.2.Final` → `6.0.3.Final`